### PR TITLE
F/persist books data

### DIFF
--- a/ReadingQuantified/Podfile
+++ b/ReadingQuantified/Podfile
@@ -7,6 +7,7 @@ target 'ReadingQuantified' do
 
   # Pods for ReadingQuantified
   pod 'Moya', '~> 12.0.1'
+  pod 'Moya/RxSwift', '~> 12.0.1'
   pod 'RealmSwift'
   pod 'RxCocoa'
   pod 'RxRealm'

--- a/ReadingQuantified/Podfile
+++ b/ReadingQuantified/Podfile
@@ -7,7 +7,9 @@ target 'ReadingQuantified' do
 
   # Pods for ReadingQuantified
   pod 'Moya', '~> 12.0.1'
+  pod 'RealmSwift'
   pod 'RxCocoa'
+  pod 'RxRealm'
   pod 'RxSwift'
   pod 'Swinject'
 

--- a/ReadingQuantified/Podfile.lock
+++ b/ReadingQuantified/Podfile.lock
@@ -5,6 +5,9 @@ PODS:
   - Moya/Core (12.0.1):
     - Alamofire (~> 4.1)
     - Result (~> 4.0)
+  - Moya/RxSwift (12.0.1):
+    - Moya/Core
+    - RxSwift (~> 4.0)
   - Realm (3.14.0):
     - Realm/Headers (= 3.14.0)
   - Realm/Headers (3.14.0)
@@ -25,6 +28,7 @@ PODS:
 
 DEPENDENCIES:
   - Moya (~> 12.0.1)
+  - Moya/RxSwift (~> 12.0.1)
   - RealmSwift
   - RxCocoa
   - RxRealm
@@ -68,6 +72,6 @@ SPEC CHECKSUMS:
   Swinject: 48a96cda93633cf2860697b4ce76ab5db9ebaca2
   SwinjectStoryboard: 688f096033103e66ffcf6ca678211acd7d7be505
 
-PODFILE CHECKSUM: 3b42f1a1921c9869c26b6a935325b7c21c902bdd
+PODFILE CHECKSUM: aaf89b903ce873cc7595094de3b39285dbcf7010
 
 COCOAPODS: 1.6.1

--- a/ReadingQuantified/Podfile.lock
+++ b/ReadingQuantified/Podfile.lock
@@ -5,10 +5,18 @@ PODS:
   - Moya/Core (12.0.1):
     - Alamofire (~> 4.1)
     - Result (~> 4.0)
+  - Realm (3.14.0):
+    - Realm/Headers (= 3.14.0)
+  - Realm/Headers (3.14.0)
+  - RealmSwift (3.14.0):
+    - Realm (= 3.14.0)
   - Result (4.1.0)
   - RxAtomic (4.4.2)
   - RxCocoa (4.4.2):
     - RxSwift (>= 4.4.2, ~> 4.4)
+  - RxRealm (0.7.6):
+    - RealmSwift (~> 3.0)
+    - RxSwift (~> 4.0)
   - RxSwift (4.4.2):
     - RxAtomic (>= 4.4.2, ~> 4.4)
   - Swinject (2.6.0)
@@ -17,7 +25,9 @@ PODS:
 
 DEPENDENCIES:
   - Moya (~> 12.0.1)
+  - RealmSwift
   - RxCocoa
+  - RxRealm
   - RxSwift
   - Swinject
   - SwinjectStoryboard (from `https://github.com/mdyson/SwinjectStoryboard.git`, branch `master`)
@@ -26,9 +36,12 @@ SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - Alamofire
     - Moya
+    - Realm
+    - RealmSwift
     - Result
     - RxAtomic
     - RxCocoa
+    - RxRealm
     - RxSwift
     - Swinject
 
@@ -45,13 +58,16 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   Moya: cf730b3cd9e005401ef37a85143aa141a12fd38f
+  Realm: 221b25919bb5a010a3c597d707f8df3492dcd93a
+  RealmSwift: 28f22dfa6a27b9a778cfb09471558b6afcf1022c
   Result: bd966fac789cc6c1563440b348ab2598cc24d5c7
   RxAtomic: d00e97c10db88c6f08540e0bf2752fc5a2404167
   RxCocoa: 477990dc3b4c3ff55fb0ac77e1cc06244e0aaec8
+  RxRealm: 5379eddd74f8d617ca7681d1f8d144af25b432b0
   RxSwift: 74c29b693c8e42b0f64400e8b06564575742d649
   Swinject: 48a96cda93633cf2860697b4ce76ab5db9ebaca2
   SwinjectStoryboard: 688f096033103e66ffcf6ca678211acd7d7be505
 
-PODFILE CHECKSUM: 902e70df58857b8e87cd336d54c0eb65a4349b67
+PODFILE CHECKSUM: 3b42f1a1921c9869c26b6a935325b7c21c902bdd
 
 COCOAPODS: 1.6.1

--- a/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
+++ b/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		069A9766224FEDFB00B4E302 /* BooksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069A9765224FEDFB00B4E302 /* BooksViewController.swift */; };
 		069A9768224FEE0B00B4E302 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069A9767224FEE0B00B4E302 /* SettingsViewController.swift */; };
 		06AC991522590AAE009A7E9F /* AuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC991422590AAE009A7E9F /* AuthPlugin.swift */; };
+		06D159F6226A3CB3002C00D8 /* BooksRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D159F5226A3CB3002C00D8 /* BooksRepository.swift */; };
+		06D159F8226A3CEE002C00D8 /* RemoteBooksRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */; };
 		06FB5298225998890035BCD0 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB5297225998890035BCD0 /* Session.swift */; };
 		06FB529A2259A90D0035BCD0 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB52992259A90D0035BCD0 /* Book.swift */; };
 		06FB529E2259AB080035BCD0 /* BooksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB529D2259AB080035BCD0 /* BooksService.swift */; };
@@ -86,6 +88,8 @@
 		069A9765224FEDFB00B4E302 /* BooksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksViewController.swift; sourceTree = "<group>"; };
 		069A9767224FEE0B00B4E302 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		06AC991422590AAE009A7E9F /* AuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPlugin.swift; sourceTree = "<group>"; };
+		06D159F5226A3CB3002C00D8 /* BooksRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksRepository.swift; sourceTree = "<group>"; };
+		06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBooksRepository.swift; sourceTree = "<group>"; };
 		06FB5297225998890035BCD0 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		06FB52992259A90D0035BCD0 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		06FB529D2259AB080035BCD0 /* BooksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksService.swift; sourceTree = "<group>"; };
@@ -202,6 +206,7 @@
 				069A9755224FD6B000B4E302 /* AppDelegate */,
 				069A9756224FD6BB00B4E302 /* Controllers */,
 				061904D6225428B700684100 /* Models */,
+				06D159F4226A3CA0002C00D8 /* Repositories */,
 				069A9758224FD6CC00B4E302 /* Resources */,
 				061904D12254227E00684100 /* Services */,
 				064F348D22506FC600E55415 /* ViewModels */,
@@ -264,6 +269,15 @@
 				0681C0F0224FBFD6000EF660 /* Assets.xcassets */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		06D159F4226A3CA0002C00D8 /* Repositories */ = {
+			isa = PBXGroup;
+			children = (
+				06D159F5226A3CB3002C00D8 /* BooksRepository.swift */,
+				06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */,
+			);
+			path = Repositories;
 			sourceTree = "<group>";
 		};
 		06FB52A1225A47FD0035BCD0 /* Cells */ = {
@@ -555,12 +569,14 @@
 				0681C0E7224FBFD6000EF660 /* AppDelegate.swift in Sources */,
 				065985A0226299FB009C148C /* BookViewModel.swift in Sources */,
 				061904D5225423BC00684100 /* Constants.swift in Sources */,
+				06D159F8226A3CEE002C00D8 /* RemoteBooksRepository.swift in Sources */,
 				06FB5298225998890035BCD0 /* Session.swift in Sources */,
 				06FB52A3225A48600035BCD0 /* BookCell.swift in Sources */,
 				06FB52A02259B1C90035BCD0 /* BooksViewModel.swift in Sources */,
 				06FB529E2259AB080035BCD0 /* BooksService.swift in Sources */,
 				061904D8225428C400684100 /* Token.swift in Sources */,
 				06AC991522590AAE009A7E9F /* AuthPlugin.swift in Sources */,
+				06D159F6226A3CB3002C00D8 /* BooksRepository.swift in Sources */,
 				069A9764224FEDF000B4E302 /* DashboardViewController.swift in Sources */,
 				0659859C22628C9C009C148C /* BookDetailViewController.swift in Sources */,
 				069A9768224FEE0B00B4E302 /* SettingsViewController.swift in Sources */,

--- a/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
+++ b/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		065985A0226299FB009C148C /* BookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0659859F226299FB009C148C /* BookViewModel.swift */; };
 		0681C0E7224FBFD6000EF660 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0681C0E6224FBFD6000EF660 /* AppDelegate.swift */; };
 		0681C0EC224FBFD6000EF660 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0681C0EA224FBFD6000EF660 /* Main.storyboard */; };
-		0681C0EF224FBFD6000EF660 /* ReadingQuantified.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 0681C0ED224FBFD6000EF660 /* ReadingQuantified.xcdatamodeld */; };
 		0681C0F1224FBFD6000EF660 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0681C0F0224FBFD6000EF660 /* Assets.xcassets */; };
 		0681C0F4224FBFD6000EF660 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0681C0F2224FBFD6000EF660 /* LaunchScreen.storyboard */; };
 		0681C0FF224FBFD6000EF660 /* ReadingQuantifiedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0681C0FE224FBFD6000EF660 /* ReadingQuantifiedTests.swift */; };
@@ -68,7 +67,6 @@
 		0681C0E3224FBFD5000EF660 /* ReadingQuantified.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ReadingQuantified.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0681C0E6224FBFD6000EF660 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		0681C0EB224FBFD6000EF660 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
-		0681C0EE224FBFD6000EF660 /* ReadingQuantified.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = ReadingQuantified.xcdatamodel; sourceTree = "<group>"; };
 		0681C0F0224FBFD6000EF660 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0681C0F3224FBFD6000EF660 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0681C0F5224FBFD6000EF660 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -264,7 +262,6 @@
 			children = (
 				0681C0F5224FBFD6000EF660 /* Info.plist */,
 				0681C0F0224FBFD6000EF660 /* Assets.xcassets */,
-				0681C0ED224FBFD6000EF660 /* ReadingQuantified.xcdatamodeld */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -468,9 +465,12 @@
 				"${PODS_ROOT}/Target Support Files/Pods-ReadingQuantified/Pods-ReadingQuantified-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
+				"${BUILT_PRODUCTS_DIR}/Realm/Realm.framework",
+				"${BUILT_PRODUCTS_DIR}/RealmSwift/RealmSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
 				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
+				"${BUILT_PRODUCTS_DIR}/RxRealm/RxRealm.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/Swinject/Swinject.framework",
 				"${BUILT_PRODUCTS_DIR}/SwinjectStoryboard/SwinjectStoryboard.framework",
@@ -481,9 +481,12 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Realm.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RealmSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxRealm.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Swinject.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwinjectStoryboard.framework",
@@ -552,7 +555,6 @@
 				0681C0E7224FBFD6000EF660 /* AppDelegate.swift in Sources */,
 				065985A0226299FB009C148C /* BookViewModel.swift in Sources */,
 				061904D5225423BC00684100 /* Constants.swift in Sources */,
-				0681C0EF224FBFD6000EF660 /* ReadingQuantified.xcdatamodeld in Sources */,
 				06FB5298225998890035BCD0 /* SessionService.swift in Sources */,
 				06FB52A3225A48600035BCD0 /* BookCell.swift in Sources */,
 				06FB52A02259B1C90035BCD0 /* BooksViewModel.swift in Sources */,
@@ -897,19 +899,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCVersionGroup section */
-		0681C0ED224FBFD6000EF660 /* ReadingQuantified.xcdatamodeld */ = {
-			isa = XCVersionGroup;
-			children = (
-				0681C0EE224FBFD6000EF660 /* ReadingQuantified.xcdatamodel */,
-			);
-			currentVersion = 0681C0EE224FBFD6000EF660 /* ReadingQuantified.xcdatamodel */;
-			path = ReadingQuantified.xcdatamodeld;
-			sourceTree = "<group>";
-			versionGroupType = wrapper.xcdatamodel;
-		};
-/* End XCVersionGroup section */
 	};
 	rootObject = 0681C0DB224FBFD5000EF660 /* Project object */;
 }

--- a/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
+++ b/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		069A9766224FEDFB00B4E302 /* BooksViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069A9765224FEDFB00B4E302 /* BooksViewController.swift */; };
 		069A9768224FEE0B00B4E302 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069A9767224FEE0B00B4E302 /* SettingsViewController.swift */; };
 		06AC991522590AAE009A7E9F /* AuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC991422590AAE009A7E9F /* AuthPlugin.swift */; };
-		06FB5298225998890035BCD0 /* SessionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB5297225998890035BCD0 /* SessionService.swift */; };
+		06FB5298225998890035BCD0 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB5297225998890035BCD0 /* Session.swift */; };
 		06FB529A2259A90D0035BCD0 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB52992259A90D0035BCD0 /* Book.swift */; };
 		06FB529E2259AB080035BCD0 /* BooksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB529D2259AB080035BCD0 /* BooksService.swift */; };
 		06FB52A02259B1C90035BCD0 /* BooksViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB529F2259B1C90035BCD0 /* BooksViewModel.swift */; };
@@ -86,7 +86,7 @@
 		069A9765224FEDFB00B4E302 /* BooksViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksViewController.swift; sourceTree = "<group>"; };
 		069A9767224FEE0B00B4E302 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		06AC991422590AAE009A7E9F /* AuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPlugin.swift; sourceTree = "<group>"; };
-		06FB5297225998890035BCD0 /* SessionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionService.swift; sourceTree = "<group>"; };
+		06FB5297225998890035BCD0 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		06FB52992259A90D0035BCD0 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		06FB529D2259AB080035BCD0 /* BooksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksService.swift; sourceTree = "<group>"; };
 		06FB529F2259B1C90035BCD0 /* BooksViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksViewModel.swift; sourceTree = "<group>"; };
@@ -134,7 +134,6 @@
 			children = (
 				06AC991422590AAE009A7E9F /* AuthPlugin.swift */,
 				06FB529D2259AB080035BCD0 /* BooksService.swift */,
-				06FB5297225998890035BCD0 /* SessionService.swift */,
 				061904D22254229200684100 /* TokenService.swift */,
 			);
 			path = Services;
@@ -198,6 +197,7 @@
 			isa = PBXGroup;
 			children = (
 				061904D4225423BC00684100 /* Constants.swift */,
+				06FB5297225998890035BCD0 /* Session.swift */,
 				068D18FD2251062800C5F9EC /* SwinjectStoryboardSetup.swift */,
 				069A9755224FD6B000B4E302 /* AppDelegate */,
 				069A9756224FD6BB00B4E302 /* Controllers */,
@@ -555,7 +555,7 @@
 				0681C0E7224FBFD6000EF660 /* AppDelegate.swift in Sources */,
 				065985A0226299FB009C148C /* BookViewModel.swift in Sources */,
 				061904D5225423BC00684100 /* Constants.swift in Sources */,
-				06FB5298225998890035BCD0 /* SessionService.swift in Sources */,
+				06FB5298225998890035BCD0 /* Session.swift in Sources */,
 				06FB52A3225A48600035BCD0 /* BookCell.swift in Sources */,
 				06FB52A02259B1C90035BCD0 /* BooksViewModel.swift in Sources */,
 				06FB529E2259AB080035BCD0 /* BooksService.swift in Sources */,

--- a/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
+++ b/ReadingQuantified/ReadingQuantified.xcodeproj/project.pbxproj
@@ -31,6 +31,8 @@
 		06AC991522590AAE009A7E9F /* AuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06AC991422590AAE009A7E9F /* AuthPlugin.swift */; };
 		06D159F6226A3CB3002C00D8 /* BooksRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D159F5226A3CB3002C00D8 /* BooksRepository.swift */; };
 		06D159F8226A3CEE002C00D8 /* RemoteBooksRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */; };
+		06EDE971226A981F008230DD /* LocalBooksRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EDE970226A981F008230DD /* LocalBooksRepository.swift */; };
+		06EDE975226A9D06008230DD /* BooksRepositoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06EDE974226A9D06008230DD /* BooksRepositoryManager.swift */; };
 		06FB5298225998890035BCD0 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB5297225998890035BCD0 /* Session.swift */; };
 		06FB529A2259A90D0035BCD0 /* Book.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB52992259A90D0035BCD0 /* Book.swift */; };
 		06FB529E2259AB080035BCD0 /* BooksService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB529D2259AB080035BCD0 /* BooksService.swift */; };
@@ -90,6 +92,8 @@
 		06AC991422590AAE009A7E9F /* AuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPlugin.swift; sourceTree = "<group>"; };
 		06D159F5226A3CB3002C00D8 /* BooksRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksRepository.swift; sourceTree = "<group>"; };
 		06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBooksRepository.swift; sourceTree = "<group>"; };
+		06EDE970226A981F008230DD /* LocalBooksRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalBooksRepository.swift; sourceTree = "<group>"; };
+		06EDE974226A9D06008230DD /* BooksRepositoryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksRepositoryManager.swift; sourceTree = "<group>"; };
 		06FB5297225998890035BCD0 /* Session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		06FB52992259A90D0035BCD0 /* Book.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Book.swift; sourceTree = "<group>"; };
 		06FB529D2259AB080035BCD0 /* BooksService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooksService.swift; sourceTree = "<group>"; };
@@ -275,6 +279,8 @@
 			isa = PBXGroup;
 			children = (
 				06D159F5226A3CB3002C00D8 /* BooksRepository.swift */,
+				06EDE974226A9D06008230DD /* BooksRepositoryManager.swift */,
+				06EDE970226A981F008230DD /* LocalBooksRepository.swift */,
 				06D159F7226A3CEE002C00D8 /* RemoteBooksRepository.swift */,
 			);
 			path = Repositories;
@@ -565,6 +571,7 @@
 				069A9766224FEDFB00B4E302 /* BooksViewController.swift in Sources */,
 				06FB529A2259A90D0035BCD0 /* Book.swift in Sources */,
 				068D18FE2251062800C5F9EC /* SwinjectStoryboardSetup.swift in Sources */,
+				06EDE975226A9D06008230DD /* BooksRepositoryManager.swift in Sources */,
 				069A975C224FDFAC00B4E302 /* LoginViewController.swift in Sources */,
 				0681C0E7224FBFD6000EF660 /* AppDelegate.swift in Sources */,
 				065985A0226299FB009C148C /* BookViewModel.swift in Sources */,
@@ -581,6 +588,7 @@
 				0659859C22628C9C009C148C /* BookDetailViewController.swift in Sources */,
 				069A9768224FEE0B00B4E302 /* SettingsViewController.swift in Sources */,
 				064F3495225079BC00E55415 /* LoginViewModel.swift in Sources */,
+				06EDE971226A981F008230DD /* LocalBooksRepository.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ReadingQuantified/ReadingQuantified/Constants.swift
+++ b/ReadingQuantified/ReadingQuantified/Constants.swift
@@ -7,8 +7,8 @@
 //
 
 struct Constants {
-//    static let baseURL = "https://reading-quantified-server.herokuapp.com"
-    static let baseURL = "http://localhost:8000"
+    static let baseURL = "https://reading-quantified-server.herokuapp.com"
+//    static let baseURL = "http://localhost:8000"
     
     // Segue Identifiers
     struct SegueIdentifiers {

--- a/ReadingQuantified/ReadingQuantified/Constants.swift
+++ b/ReadingQuantified/ReadingQuantified/Constants.swift
@@ -7,8 +7,8 @@
 //
 
 struct Constants {
-    static let baseURL = "https://reading-quantified-server.herokuapp.com"
-//    static let baseURL = "http://localhost:8000"
+//    static let baseURL = "https://reading-quantified-server.herokuapp.com"
+    static let baseURL = "http://localhost:8000"
     
     // Segue Identifiers
     struct SegueIdentifiers {

--- a/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
+++ b/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
@@ -40,12 +40,16 @@ class BooksViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(BooksViewController.keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(BooksViewController.keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
         
+        // Load books from local repository
         viewModel.loadBooks()
         
         bindSearchBar()
         bindSegmentedControl()
         bindNumberOfBooksLabel()
         bindTableView()
+        
+        // Fetch updates from remote repository
+        viewModel.refreshBooks()
     }
     
     // MARK: - Keyboard Functions

--- a/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
+++ b/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
@@ -109,7 +109,7 @@ class BooksViewController: UIViewController {
     }
     
     private func bindNumberOfBooksLabel() {
-        viewModel.books.asObservable()
+        viewModel.booksRelay.asObservable()
             .subscribe(onNext: { [weak self] items in
                 guard let strongSelf = self else { return }
                 
@@ -119,7 +119,7 @@ class BooksViewController: UIViewController {
     }
     
     private func bindTableView() {
-        viewModel.books.asObservable()
+        viewModel.booksRelay.asObservable()
             .bind(to: tableView.rx.items(cellIdentifier: "BookCell", cellType: BookCell.self)) { row, book, cell in
                 cell.configureCell(book: book)
             }

--- a/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
+++ b/ReadingQuantified/ReadingQuantified/Controllers/BooksViewController.swift
@@ -19,6 +19,7 @@ class BooksViewController: UIViewController {
     // MARK: - Private Properties
     
     private let bag = DisposeBag()
+    private let refreshControl = UIRefreshControl()
     private var selectedBook: Book?
     
     // MARK: - IB Outlets & Actions
@@ -42,6 +43,8 @@ class BooksViewController: UIViewController {
         
         // Load books from local repository
         viewModel.loadBooks()
+        
+        setupRefreshControl()
         
         bindSearchBar()
         bindSegmentedControl()
@@ -144,6 +147,22 @@ class BooksViewController: UIViewController {
     private func updateTableViewInsets(for bottomValue: CGFloat) {
         tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: bottomValue, right: 0)
         tableView.scrollIndicatorInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomValue, right: 0)
+    }
+    
+    private func setupRefreshControl() {
+        tableView.refreshControl = refreshControl
+        
+        refreshControl.backgroundColor = UIColor(named: "bg_white")
+        refreshControl.tintColor = UIColor(named: "text_muted")
+        refreshControl.attributedTitle = NSAttributedString(string: "Fetching books...",
+                                                            attributes: [NSAttributedString.Key.foregroundColor: UIColor(named: "text_muted")!])
+        refreshControl.addTarget(self, action: #selector(handleRefresh(_:)), for: .valueChanged)
+    }
+    
+    @objc private func handleRefresh(_ refreshControl: UIRefreshControl) {
+        viewModel.refreshBooks()
+        tableView.reloadData()
+        refreshControl.endRefreshing()
     }
     
     // MARK: - Navigation

--- a/ReadingQuantified/ReadingQuantified/Models/Book.swift
+++ b/ReadingQuantified/ReadingQuantified/Models/Book.swift
@@ -6,13 +6,65 @@
 //  Copyright © 2019 Esther Jun Kim. All rights reserved.
 //
 
-struct Book: Decodable {
-    let url: String
-    let genres: [String]
-    let created_at: String
-    let updated_at: String
-    let title: String
-    let trello_id: String
-    let date_started: String
-    let date_finished: String
+import Realm
+import RealmSwift
+
+class Book: Object, Decodable {
+    
+    @objc dynamic var url = ""
+    let genres = List<String>()
+    @objc dynamic var created_at = ""
+    @objc dynamic var updated_at = ""
+    @objc dynamic var title = ""
+    @objc dynamic var trello_id = ""
+    @objc dynamic var date_started = ""
+    @objc dynamic var date_finished = ""
+    
+    override static func primaryKey() -> String? {
+        return "trello_id"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case url
+        case genres
+        case created_at
+        case updated_at
+        case title
+        case trello_id
+        case date_started
+        case date_finished
+    }
+    
+    // MARK: - Decodable initializers
+    
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        url = try container.decode(String.self, forKey: .url)
+        created_at = try container.decode(String.self, forKey: .created_at)
+        updated_at = try container.decode(String.self, forKey: .updated_at)
+        title = try container.decode(String.self, forKey: .title)
+        trello_id = try container.decode(String.self, forKey: .trello_id)
+        date_started = try container.decode(String.self, forKey: .date_started)
+        date_finished = try container.decode(String.self, forKey: .date_finished)
+        
+        let genresArray = try container.decode([String].self, forKey: .genres)
+        genres.append(objectsIn: genresArray)
+        
+        super.init()
+    }
+    
+    // MARK: - Object initializers
+    
+    required init() {
+        super.init()
+    }
+    
+    required init(realm: RLMRealm, schema: RLMObjectSchema) {
+        super.init(realm: realm, schema: schema)
+    }
+    
+    required init(value: Any, schema: RLMSchema) {
+        super.init(value: value, schema: schema)
+    }
 }

--- a/ReadingQuantified/ReadingQuantified/Repositories/BooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/BooksRepository.swift
@@ -1,0 +1,15 @@
+//
+//  BooksRepository.swift
+//  ReadingQuantified
+//
+//  Created by Esther Jun Kim on 4/19/19.
+//  Copyright © 2019 Esther Jun Kim. All rights reserved.
+//
+
+import RxSwift
+
+protocol BooksRepository {
+    
+    func getAll() -> Observable<[Book]>
+    
+}

--- a/ReadingQuantified/ReadingQuantified/Repositories/BooksRepositoryManager.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/BooksRepositoryManager.swift
@@ -1,0 +1,46 @@
+//
+//  BooksRepositoryManager.swift
+//  ReadingQuantified
+//
+//  Created by Esther Jun Kim on 4/19/19.
+//  Copyright © 2019 Esther Jun Kim. All rights reserved.
+//
+
+import RxSwift
+import RxCocoa
+
+class BooksRepositoryManager {
+    
+    // MARK: - Dependencies
+    
+    private let local: LocalBooksRepository
+    private let remote: RemoteBooksRepository
+    
+    init(local: LocalBooksRepository, remote: RemoteBooksRepository) {
+        self.local = local
+        self.remote = remote
+    }
+    
+    // MARK: - Properties
+    
+    enum RepositoryType {
+        case local, remote
+    }
+    
+    // MARK: - Functions
+    
+    func getAll(from source: RepositoryType) -> Observable<[Book]> {
+        switch source {
+        case .local:
+            return local.getAll()
+        case .remote:
+            return remote.getAll()
+        }
+    }
+    
+    func save() -> Observable<Bool> {
+        
+        return local.save()
+    }
+    
+}

--- a/ReadingQuantified/ReadingQuantified/Repositories/BooksRepositoryManager.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/BooksRepositoryManager.swift
@@ -38,9 +38,9 @@ class BooksRepositoryManager {
         }
     }
     
-    func save() -> Observable<Bool> {
+    func save(_ books: [Book]) {
         
-        return local.save()
+        return local.save(books)
     }
     
 }

--- a/ReadingQuantified/ReadingQuantified/Repositories/LocalBooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/LocalBooksRepository.swift
@@ -1,0 +1,38 @@
+//
+//  LocalBooksRepository.swift
+//  ReadingQuantified
+//
+//  Created by Esther Jun Kim on 4/19/19.
+//  Copyright © 2019 Esther Jun Kim. All rights reserved.
+//
+
+import RxSwift
+
+class LocalBooksRepository: BooksRepository {
+    
+    // TODO: Hard-code books variable for now
+    var books: [Book] = [
+        Book(url: "http://localhost:8000/api/books/1/",
+             genres: ["564d07a87721d8698ff010d8"],
+             created_at: "2019-04-06T16:46:00.354844Z",
+             updated_at: "2019-04-06T16:46:00.354863Z",
+             title: "The Age of Innocence",
+             trello_id: "564d07a87721d8698ff010f3",
+             date_started: "2016-06-18T16:18:30.373000Z",
+             date_finished: "2016-06-29T02:39:03.355000Z")
+    ]
+    
+    
+    func getAll() -> Observable<[Book]> {
+        
+        // TODO: Return Realm observable... return hard-coded books variable for now
+        return Observable<[Book]>.just(books)
+    }
+    
+    func save() -> Observable<Bool> {
+        
+        // TODO: Implement function
+        return Observable<Bool>.just(false)
+    }
+    
+}

--- a/ReadingQuantified/ReadingQuantified/Repositories/LocalBooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/LocalBooksRepository.swift
@@ -6,33 +6,27 @@
 //  Copyright © 2019 Esther Jun Kim. All rights reserved.
 //
 
+import Realm
+import RealmSwift
 import RxSwift
+import RxRealm
 
 class LocalBooksRepository: BooksRepository {
     
-    // TODO: Hard-code books variable for now
-    var books: [Book] = [
-        Book(url: "http://localhost:8000/api/books/1/",
-             genres: ["564d07a87721d8698ff010d8"],
-             created_at: "2019-04-06T16:46:00.354844Z",
-             updated_at: "2019-04-06T16:46:00.354863Z",
-             title: "The Age of Innocence",
-             trello_id: "564d07a87721d8698ff010f3",
-             date_started: "2016-06-18T16:18:30.373000Z",
-             date_finished: "2016-06-29T02:39:03.355000Z")
-    ]
-    
-    
     func getAll() -> Observable<[Book]> {
+        let realm = try! Realm()
+        let books = realm.objects(Book.self)
         
-        // TODO: Return Realm observable... return hard-coded books variable for now
-        return Observable<[Book]>.just(books)
+        return Observable.array(from: books, synchronousStart: false)
     }
     
-    func save() -> Observable<Bool> {
+    func save(_ books: [Book]) {
+        let realm = try! Realm()
         
-        // TODO: Implement function
-        return Observable<Bool>.just(false)
+        try! realm.write {
+            // Overwrite an object if it already exists
+            realm.add(books, update: true)
+        }
     }
     
 }

--- a/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
@@ -1,0 +1,29 @@
+//
+//  RemoteBooksRepository.swift
+//  ReadingQuantified
+//
+//  Created by Esther Jun Kim on 4/19/19.
+//  Copyright © 2019 Esther Jun Kim. All rights reserved.
+//
+
+import Moya
+import RxSwift
+
+class RemoteBooksRepository: BooksRepository {
+    
+    private let token: Token
+    private let provider: MoyaProvider<BooksService>
+    
+    init(token: Token) {
+        self.token = token
+        self.provider = MoyaProvider<BooksService>(plugins: [AuthPlugin(accessToken: token.access)])
+    }
+    
+    func getAll() -> Observable<[Book]> {
+        return provider.rx.request(.getBooks)
+            .filterSuccessfulStatusCodes()
+            .map([Book].self)
+            .asObservable()
+    }
+    
+}

--- a/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
@@ -18,7 +18,9 @@ class RemoteBooksRepository: BooksRepository {
         self.session = session
         
         // QUESTION: Is force unwrapping token okay?
-        self.provider = MoyaProvider<BooksService>(plugins: [AuthPlugin(accessToken: session.token!.access)])
+        self.provider = MoyaProvider<BooksService>(plugins: [
+            AuthPlugin(accessToken: session.token!.access),
+            NetworkLoggerPlugin(verbose: true)])
     }
     
     func getAll() -> Observable<[Book]> {

--- a/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
+++ b/ReadingQuantified/ReadingQuantified/Repositories/RemoteBooksRepository.swift
@@ -11,12 +11,14 @@ import RxSwift
 
 class RemoteBooksRepository: BooksRepository {
     
-    private let token: Token
+    private let session: Session
     private let provider: MoyaProvider<BooksService>
     
-    init(token: Token) {
-        self.token = token
-        self.provider = MoyaProvider<BooksService>(plugins: [AuthPlugin(accessToken: token.access)])
+    init(session: Session) {
+        self.session = session
+        
+        // QUESTION: Is force unwrapping token okay?
+        self.provider = MoyaProvider<BooksService>(plugins: [AuthPlugin(accessToken: session.token!.access)])
     }
     
     func getAll() -> Observable<[Book]> {

--- a/ReadingQuantified/ReadingQuantified/Resources/ReadingQuantified.xcdatamodeld/.xccurrentversion
+++ b/ReadingQuantified/ReadingQuantified/Resources/ReadingQuantified.xcdatamodeld/.xccurrentversion
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>_XCCurrentVersionName</key>
-	<string>ReadingQuantified.xcdatamodel</string>
-</dict>
-</plist>

--- a/ReadingQuantified/ReadingQuantified/Resources/ReadingQuantified.xcdatamodeld/ReadingQuantified.xcdatamodel/contents
+++ b/ReadingQuantified/ReadingQuantified/Resources/ReadingQuantified.xcdatamodeld/ReadingQuantified.xcdatamodel/contents
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <elements/>
-</model>

--- a/ReadingQuantified/ReadingQuantified/Session.swift
+++ b/ReadingQuantified/ReadingQuantified/Session.swift
@@ -1,12 +1,12 @@
 //
-//  SessionService.swift
+//  Session.swift
 //  ReadingQuantified
 //
 //  Created by Esther Jun Kim on 4/6/19.
 //  Copyright © 2019 Esther Jun Kim. All rights reserved.
 //
 
-class SessionService {
+class Session {
     
     var token: Token? {
         // TEST: Print out token values

--- a/ReadingQuantified/ReadingQuantified/Session.swift
+++ b/ReadingQuantified/ReadingQuantified/Session.swift
@@ -6,14 +6,10 @@
 //  Copyright © 2019 Esther Jun Kim. All rights reserved.
 //
 
+import Moya
+
 class Session {
     
-    var token: Token? {
-        // TEST: Print out token values
-        didSet {
-            print(token!.access)
-            print(token!.refresh)
-        }
-    }
+    var token: Token?
     
 }

--- a/ReadingQuantified/ReadingQuantified/SwinjectStoryboardSetup.swift
+++ b/ReadingQuantified/ReadingQuantified/SwinjectStoryboardSetup.swift
@@ -30,17 +30,17 @@ extension SwinjectStoryboard {
         // MARK: - View Model Injections
         
         defaultContainer.register(BooksViewModel.self) { resolver in
-            BooksViewModel(session: resolver.resolve(SessionService.self)!)
+            BooksViewModel(session: resolver.resolve(Session.self)!)
         }
         
         defaultContainer.register(LoginViewModel.self) { resolver in
-            LoginViewModel(session: resolver.resolve(SessionService.self)!)
+            LoginViewModel(session: resolver.resolve(Session.self)!)
         }
         
         // MARK: - App Component Injections
         
-        defaultContainer.register(SessionService.self) { _ in
-            SessionService()
+        defaultContainer.register(Session.self) { _ in
+            Session()
         }.inObjectScope(.container)
     }
     

--- a/ReadingQuantified/ReadingQuantified/SwinjectStoryboardSetup.swift
+++ b/ReadingQuantified/ReadingQuantified/SwinjectStoryboardSetup.swift
@@ -30,7 +30,7 @@ extension SwinjectStoryboard {
         // MARK: - View Model Injections
         
         defaultContainer.register(BooksViewModel.self) { resolver in
-            BooksViewModel(session: resolver.resolve(Session.self)!)
+            BooksViewModel(booksRepositoryManager: resolver.resolve(BooksRepositoryManager.self)!)
         }
         
         defaultContainer.register(LoginViewModel.self) { resolver in
@@ -41,6 +41,19 @@ extension SwinjectStoryboard {
         
         defaultContainer.register(Session.self) { _ in
             Session()
+        }.inObjectScope(.container)
+        
+        defaultContainer.register(LocalBooksRepository.self) { _ in
+            LocalBooksRepository()
+        }.inObjectScope(.container)
+        
+        defaultContainer.register(RemoteBooksRepository.self) { resolver in
+            RemoteBooksRepository(session: resolver.resolve(Session.self)!)
+        }.inObjectScope(.container)
+        
+        defaultContainer.register(BooksRepositoryManager.self) { resolver in
+            BooksRepositoryManager(local: resolver.resolve(LocalBooksRepository.self)!,
+                                   remote: resolver.resolve(RemoteBooksRepository.self)!)
         }.inObjectScope(.container)
     }
     

--- a/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
+++ b/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
@@ -20,12 +20,12 @@ class BooksViewModel {
     
     // MARK: - Properties
     
-    var books = BehaviorRelay<[Book]>(value: [])
+    var booksRelay = BehaviorRelay<[Book]>(value: [])
     
     // MARK: - Private Properties
     
     private let bag = DisposeBag()
-    private var bookResults: [Book] = []
+    private var books: [Book] = []
     
     private enum Segment: Int {
         case Title, DateStarted, DateFinished
@@ -36,31 +36,26 @@ class BooksViewModel {
     func loadBooks() {
         guard let token = self.session.token else { return }
         
-        let provider = MoyaProvider<BooksService>(plugins: [AuthPlugin(accessToken: token.access)])
-        provider.request(.getBooks) { result in
-            switch result {
-            case let .success(response):
-                do {
-                    self.bookResults = try response.map([Book].self)
-                    self.books.accept(self.bookResults)
-                } catch let error {
-                    print(error)
-                }
+        // TODO: Determine best way to get books from remote or local repository
+        let remoteBooksRepository = RemoteBooksRepository(token: token)
+        remoteBooksRepository.getAll()
+            .subscribe(onNext: { [weak self] books in
+                guard let strongSelf = self else { return }
                 
-            case let .failure(error):
-                print(error)
-            }
-        }
+                strongSelf.books = books
+                strongSelf.booksRelay.accept(books)
+            })
+            .disposed(by: bag)
     }
     
     func filterBooks(by query: String) {
         // Show the entire list of available books if there is no search term
         if(query.isEmpty) {
-            books.accept(self.bookResults)
+            booksRelay.accept(self.books)
         }
         // Filtering should be done on the original list of book results
         else {
-            books.accept(self.bookResults.filter({ (item) -> Bool in
+            booksRelay.accept(self.books.filter({ (item) -> Bool in
                 return item.title.lowercased().contains(query.lowercased()) ||
                     
                        // TODO: Enhance date search
@@ -76,17 +71,17 @@ class BooksViewModel {
         switch selectedSegment {
         case .Title:
             // Sort alphabetically
-            books.accept(books.value.sorted(by: { (item1, item2) -> Bool in
+            booksRelay.accept(booksRelay.value.sorted(by: { (item1, item2) -> Bool in
                 item1.title < item2.title
             }))
         case .DateStarted:
             // Sort date in descending order
-            books.accept(books.value.sorted(by: { (item1, item2) -> Bool in
+            booksRelay.accept(booksRelay.value.sorted(by: { (item1, item2) -> Bool in
                 item1.date_started > item2.date_started
             }))
         case .DateFinished:
             // Sort date in descending order
-            books.accept(books.value.sorted(by: { (item1, item2) -> Bool in
+            booksRelay.accept(booksRelay.value.sorted(by: { (item1, item2) -> Bool in
                 item1.date_finished > item2.date_finished
             }))
         }

--- a/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
+++ b/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
@@ -53,6 +53,7 @@ class BooksViewModel {
                 
                 strongSelf.books = books
                 strongSelf.booksRelay.accept(books)
+                strongSelf.booksRepositoryManager.save(books)
             })
             .disposed(by: bag)
     }

--- a/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
+++ b/ReadingQuantified/ReadingQuantified/ViewModels/BooksViewModel.swift
@@ -12,9 +12,9 @@ import RxCocoa
 
 class BooksViewModel {
     
-    private let session: SessionService
+    private let session: Session
     
-    init(session: SessionService) {
+    init(session: Session) {
         self.session = session
     }
     

--- a/ReadingQuantified/ReadingQuantified/ViewModels/LoginViewModel.swift
+++ b/ReadingQuantified/ReadingQuantified/ViewModels/LoginViewModel.swift
@@ -12,9 +12,9 @@ import RxCocoa
 
 class LoginViewModel {
     
-    private let session: SessionService
+    private let session: Session
     
-    init(session: SessionService) {
+    init(session: Session) {
         self.session = session
     }
     


### PR DESCRIPTION
- Realm is used to persist the books data; Core data files have been removed from the project.
- The repository pattern is used to fetch books from Realm (local) or the web (remote); a Repository Manager coordinates the calls.
- A refresh control has been added to the Books table view.